### PR TITLE
- Modified vnx_autoconfigure to avoid the access from vnxaced to the

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+
+16/3/2020
+- Modified vnx_autoconfigure to avoid the access from vnxaced to the full XML (an access to $dh prevented it to work).
+- vmAPI_lxc: created a link in /var/run/netns to make the containers network namespaces visible to be used by "ip netns" command.
+- vnx.pl and CheckSemantics: modified to allow use of relative paths in ssh_key tags.
+
+3/12/2019
+
+- Changed --create-rootfs and --modify-rootfs defaults to 1G, x86_64 and 2 vcpus
+- Added LICENSE file
+
 28/8/2019
 
 - vmAPI_libvirt: added new type libvirt-qemu-linux to allow the execution of light virtual machines like tinycore without KVM 

--- a/LICENSE
+++ b/LICENSE
@@ -23,7 +23,7 @@
 #             Jorge Rodriguez (jrodriguez@dit.upm.es),
 #             Carlos González (carlosgonzalez@dit.upm.es)
 # Project coordinated by: 
-#              David Fernández (david.fernandez@upm.es)
+#             David Fernández (david.fernandez@upm.es)
 #
 # ----------------------------------------------------------------------------------
 #

--- a/admin-scripts/VERSION
+++ b/admin-scripts/VERSION
@@ -8,4 +8,4 @@ VNX_MAJOR="2"
 VNX_MINOR="0b"
 
 # Automatically self updated (do not edit):
-VNX_LATEST_REVISION="6604"
+VNX_LATEST_REVISION="6648"

--- a/vnx-autoconf/open-source/linux/vnxaced.pl
+++ b/vnx-autoconf/open-source/linux/vnxaced.pl
@@ -1101,7 +1101,7 @@ EOF
         wlog (V, "-------------------------\r\n"); 
 
         if    ($platform[1] eq 'ubuntu')   
-            { autoconfigure_debian_ubuntu ($dom, '/', 'ubuntu', 'yes') }           
+            { autoconfigure_debian_ubuntu ($dom, '/', 'ubuntu-'. $platform[2], 'yes') }           
         elsif ($platform[1] eq 'debian' || $platform[1] eq 'kali')   
             { autoconfigure_debian_ubuntu ($dom, '/', 'debian', 'yes') }           
         elsif ($platform[1] eq 'fedora')   

--- a/vnx-folder/bin/vnx_create_kvm_rootfs.sh
+++ b/vnx-folder/bin/vnx_create_kvm_rootfs.sh
@@ -7,8 +7,8 @@
 #
 # This file is a module part of VNX package.
 #
-# Authors: David Fernández (david@dit.upm.es)
-# Copyright (C) 2018 DIT-UPM
+# Author: David Fernández (david@dit.upm.es)
+# Copyright (C) 2019 DIT-UPM
 #           Departamento de Ingenieria de Sistemas Telematicos
 #           Universidad Politecnica de Madrid
 #           SPAIN
@@ -244,7 +244,7 @@ wget ${IMGSRVURL}${IMG}
 
 # Resize image 
 echo "--"
-echo "-- Resizing image to ${IMG2SIZE}..."
+echo "-- Resizing image ${IMG} to ${IMG2SIZE}..."
 qemu-img resize ${IMG} ${IMG2SIZE}
 
 # Convert img to qcow2 format and change name

--- a/vnx-folder/bin/vnx_create_lxc_rootfs.sh
+++ b/vnx-folder/bin/vnx_create_lxc_rootfs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Name: create-rootfs
+# Name: vnx_create_lxc_rootfs
 #
 # Description: creates a customized LXC VNX rootfs starting from a basic VNX LXC rootfs
 #
@@ -228,8 +228,7 @@ function create_rootfs_tgz {
   tmpfile=$(mktemp)
   find ${ROOTFSNAME} -type s > $tmpfile
   #cat $tmpfile
-  size=$(du -sb --apparent-size ${ROOTFSNAME} | awk '{ total += $1 - 512; }; END { print total }')
-  size=$(( $size * 1020 / 1000 ))
+  size=$(du -sb --apparent-size ${ROOTFSNAME} | awk '{ total += $1 - 512; }; END { printf "%.0f", total*1020/1000 }')
   LANG=C tar --numeric-owner -cpf - ${ROOTFSNAME} -X $tmpfile | pv -p -s $size | gzip > ${ROOTFSNAME}.tgz
   for LINK in $ROOTFSLINKNAME; do
     rm -f $LINK

--- a/vnx-folder/bin/vnx_mount_rootfs.sh
+++ b/vnx-folder/bin/vnx_mount_rootfs.sh
@@ -328,12 +328,12 @@ if [[ $umount == "no" ]]; then
             exit 9
         fi
         # some time partition devices are not created, we use partx for that
-        if ! partx -a $dev; then 
-            write_msg ""
-            write_msg "ERROR executing 'part -a $dev'"
-            qemu-nbd -d $dev
-            exit 13
-		fi
+        #if ! partx -a $dev; then 
+        #    write_msg ""
+        #    write_msg "ERROR executing 'part -a $dev'"
+        #    qemu-nbd -d $dev
+        #    exit 13
+		#fi
 
         #read -p "Press any key..."
         sleep 1

--- a/vnx-folder/etc/vnx.conf
+++ b/vnx-folder/etc/vnx.conf
@@ -55,8 +55,8 @@ idle_pc-c7200 = 0x606e8a34
 # union_type: type of overlay file system used to create the COW lxc images
 # accepted values: overlayfs (default), aufs
 #
-#union_type = 'overlayfs'
-union_type = 'aufs'
+union_type = 'overlayfs'
+#union_type = 'aufs'
 
 #
 # aa_unconfined: activate aa_unconfined mode for LXC VMs
@@ -73,7 +73,7 @@ aufs_options = 'noxino'
 # overlayfs_workdir_option: if yes, add workdir=<workdir> to overlayfs mount options. Needed in new kernel versions 
 # like the one distributed with Ubuntu 15.04 or newer versions
 #
-overlayfs_workdir_option = no
+overlayfs_workdir_option = yes
 
 #
 # nested_lxc: allow creation of nested LXC virtual machines

--- a/vnx-folder/perl-modules/VNX/CheckSemantics.pm
+++ b/vnx-folder/perl-modules/VNX/CheckSemantics.pm
@@ -257,7 +257,7 @@ sub check_doc {
     # 3. To check <ssh_key>
     foreach my $ssh_key ($doc->getElementsByTagName("ssh_key")) {
 	   my $ssh_key = &do_path_expansion(text_tag($ssh_key));
-	   return "$ssh_key is not a valid absolute filename" unless &valid_absolute_filename($ssh_key);
+	   #return "$ssh_key is not a valid absolute filename" unless &valid_absolute_filename($ssh_key);
 	   unless (-r $ssh_key) {
 root();
 	       if (-r $ssh_key) {

--- a/vnx-folder/perl-modules/VNX/vmAPI_libvirt.pm
+++ b/vnx-folder/perl-modules/VNX/vmAPI_libvirt.pm
@@ -1742,7 +1742,7 @@ user();
 		if ($platform[0] eq 'Linux'){
 		    
             if    ($platform[1] eq 'Ubuntu') 
-                { autoconfigure_debian_ubuntu ($vm_doc, $rootfs_mount_dir, 'ubuntu') }           
+                { autoconfigure_debian_ubuntu ($vm_doc, $rootfs_mount_dir, 'ubuntu-' . $platform[2]) }           
             elsif ($platform[1] eq 'Debian' || $platform[1] eq 'Kali') 
                 { autoconfigure_debian_ubuntu ($vm_doc, $rootfs_mount_dir, 'debian') }           
 		    elsif ($platform[1] eq 'Fedora') 

--- a/vnx-folder/perl-modules/VNX/vnx_autoconfigure.pl
+++ b/vnx-folder/perl-modules/VNX/vnx_autoconfigure.pl
@@ -2,8 +2,9 @@
 #
 # This file is a module part of VNX package.
 #
-# Author: David Fernández (david@dit.upm.es)
-# Copyright (C) 2018,   DIT-UPM
+# Author: David Fernández (david.fernandez@upm.es)
+#         Paola Jordan Figueroa (get_tc_cmds function)
+# Copyright (C) 2019,   DIT-UPM
 #           Departamento de Ingenieria de Sistemas Telematicos
 #           Universidad Politecnica de Madrid
 #           SPAIN
@@ -156,15 +157,15 @@ sub get_tc_cmds {
 						wlog (VVV, "-- $latency_tbf_cmd\n", $logp);
 					}
 				} else {
-					wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': rate unit not recognized. Ignoring it.", $logp);
-					wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].\n$hline", $logp);
+					wlog (N, "QoS spec syntax ERROR in '$bw': rate unit not recognized. Ignoring it.", $logp);
+					wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].", $logp);
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR: incorrect bw qos specification ($bw). Ignoring it.\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR: incorrect bw qos specification ($bw). Ignoring it.", $logp);
 			}
 		
 	    } elsif ( @bw_fields == 2 or @bw_fields > 3){
-			wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': three comma separated parameters expected. Ignoring it.\n$hline", $logp);
+			wlog (N, "QoS spec syntax ERROR in '$bw': three comma separated parameters expected. Ignoring it.", $logp);
 
 	    } else {
 		
@@ -189,16 +190,16 @@ sub get_tc_cmds {
 						$bw_queue_discipline = "tbf rate ${rate_tbf_cmd} latency ${latency_tbf_cmd} burst ${burst_tbf_cmd}";
 					}else{
 						if(!exists($rate_units{$rate_only_unit})){
-		                	wlog (N, "$hline\nQoS spec syntax ERROR: rate unit not recognized", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].\n$hline", $logp);
+		                	wlog (N, "QoS spec syntax ERROR: rate unit not recognized", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].", $logp);
 		                }
 		                if(!( exists($size_units{$burst_only_unit}) || $burst_only_unit eq '')){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': burst unit not recognized", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{size_units}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR in '$bw': burst unit not recognized", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{size_units}) . "].", $logp);
 		                }
 						if(! exists($time_units{$latency_or_limit_only_unit})){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': latency unit not recognized", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR in '$bw': latency unit not recognized", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		                }
 					}
 				}elsif($is_limit eq 'true'){
@@ -209,20 +210,20 @@ sub get_tc_cmds {
 						$bw_queue_discipline = "tbf rate ${rate_tbf_cmd} limit ${limit_tbf_cmd} burst ${burst_tbf_cmd}";
 		            }else{
 						if(!exists($rate_units{$rate_only_unit})){
-		                  	wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': rate unit not recognized", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].\n$hline", $logp);
+		                  	wlog (N, "QoS spec syntax ERROR in '$bw': rate unit not recognized", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{rate_units}) . "].", $logp);
 						}
 						if(!( exists($size_units{$burst_only_unit}) || $burst_only_unit eq '')){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': burst unit not recognized", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{size_units}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR in '$bw': burst unit not recognized", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{size_units}) . "].", $logp);
 		                }
 		            }
 				
 				}else{
-					wlog (N, "$hline\nQoS spec syntax ERROR occurred ($bw).\n$hline", $logp);
+					wlog (N, "QoS spec syntax ERROR occurred ($bw).\n", $logp);
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR in '$bw': incorrect bw parameters.\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR in '$bw': incorrect bw parameters.", $logp);
 			}
 	    }
     }
@@ -247,11 +248,11 @@ sub get_tc_cmds {
 					$delay_queue_discipline = "netem delay ${delay_netem_cmd}";
 				
 				}else{
-					wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
-					wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+					wlog (N, "QoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
+					wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR in delay parameters ($delay).\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR in delay parameters ($delay).", $logp);
 			}
 		
 	    }elsif (@delay_fields == '2'){
@@ -270,16 +271,16 @@ sub get_tc_cmds {
 				}else{
 					
 					if(! exists($time_units{$delay_only_unit})){
-		                wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
-						wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                wlog (N, "QoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
+						wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		            }
 		            if(! exists($time_units{$jitter_only_unit})){
-		                wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': jitter unit not recognized.", $logp);
-						wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                wlog (N, "QoS spec syntax ERROR in '$delay': jitter unit not recognized.", $logp);
+						wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		            }
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR  in '$delay': incorrect delay parameters\n", $logp);
+				wlog (N, "QoS spec syntax ERROR  in '$delay': incorrect delay parameters\n", $logp);
 			}
 
 	    }else{
@@ -305,16 +306,16 @@ sub get_tc_cmds {
 						$delay_queue_discipline = "netem delay ${delay_netem_cmd} ${jitter_netem_cmd} ${correlation_netem_cmd}";
 					}else{
 						if(!exists($time_units{$delay_only_unit})){
-		                	wlog (N, "$hline\nQoS spec syntax ERROR: delay unit not recognized.", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                	wlog (N, "QoS spec syntax ERROR: delay unit not recognized.", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		                }
 		                if(!exists($time_units{$jitter_only_unit})){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR: jitter unit not recognized.", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR: jitter unit not recognized.", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		                }
 						if($correlation_or_distribution_only_unit ne '%'){
-							wlog (N, "$hline\nQoS spec syntax ERROR: correlation unit not recognized.", $logp);
-							wlog (N, "The accepted units are: %\n$hline", $logp);
+							wlog (N, "QoS spec syntax ERROR: correlation unit not recognized.", $logp);
+							wlog (N, "The accepted units are: %", $logp);
 		                }
 					}
 				}elsif($is_distribution eq 'true'){
@@ -325,24 +326,24 @@ sub get_tc_cmds {
 						$delay_queue_discipline = "netem delay ${delay_netem_cmd} ${jitter_netem_cmd} distribution ${distribution_netem_cmd}";
 		            }else{
 						if(!exists($time_units{$delay_only_unit})){
-		                  	wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                  	wlog (N, "QoS spec syntax ERROR in '$delay': delay unit not recognized.", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 						}
 						if(!exists($time_units{$jitter_only_unit})){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': jitter unit not recognized.", $logp);
-							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR in '$delay': jitter unit not recognized.", $logp);
+							wlog (N, "  Accepted units are: [" . join( ',', keys %{time_units}) . "].", $logp);
 		                }
 						if(!exists($delay_distribution{$delay_fields[2]})){
-		                    wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': distribution not recognized.", $logp);
-							wlog (N, "  Accepted values are: [" . join( ',', keys %{delay_distribution}) . "].\n$hline", $logp);
+		                    wlog (N, "QoS spec syntax ERROR in '$delay': distribution not recognized.", $logp);
+							wlog (N, "  Accepted values are: [" . join( ',', keys %{delay_distribution}) . "].", $logp);
 		                }
 		            }
 				
 				}else{
-					wlog (N, "$hline\nQoS spec syntax ERROR occurred ($delay).\n$hline", $logp);
+					wlog (N, "QoS spec syntax ERROR occurred ($delay).", $logp);
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR in '$delay': incorrect delay parameters.\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR in '$delay': incorrect delay parameters.", $logp);
 			}
 	    }
 	}
@@ -365,11 +366,11 @@ sub get_tc_cmds {
 					$loss_queue_discipline = "netem loss ${loss_netem_cmd}";
 				
 				}else{
-					wlog (N, "$hline\nQoS spec syntax ERROR in '$loss': loss unit not recognized.", $logp);
-					wlog (N, "The accepted units are: %\n$hline", $logp);
+					wlog (N, "QoS spec syntax ERROR in '$loss': loss unit not recognized.", $logp);
+					wlog (N, "The accepted units are: %", $logp);
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR in '$loss': incorrect loss parameters.\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR in '$loss': incorrect loss parameters.", $logp);
 			}
 		
 	    }elsif (@loss_fields == '2'){
@@ -387,19 +388,19 @@ sub get_tc_cmds {
 				}else{
 					
 					if($loss_only_unit ne '%'){
-		                wlog (N, "$hline\nQoS spec syntax ERROR in '$loss': loss unit not recognized.", $logp);
-						wlog (N, "The accepted units are: %\n$hline", $logp);
+		                wlog (N, "QoS spec syntax ERROR in '$loss': loss unit not recognized.", $logp);
+						wlog (N, "The accepted units are: %", $logp);
 		            }
 		            if($correlation_only_unit ne '%'){
-		                wlog (N, "$hline\nQoS spec syntax ERROR in '$loss': loss correlation unit not recognized.", $logp);
-						wlog (N, "The accepted units are: %\n$hline", $logp);
+		                wlog (N, "QoS spec syntax ERROR in '$loss': loss correlation unit not recognized.", $logp);
+						wlog (N, "The accepted units are: %", $logp);
 		            }
 				}
 			}else{
-				wlog (N, "$hline\nQoS spec syntax ERROR in '$loss': incorrect loss parameters.\n$hline", $logp);
+				wlog (N, "QoS spec syntax ERROR in '$loss': incorrect loss parameters.", $logp);
 			}
 	    }else{
-			wlog (N, "$hline\nQoS spec syntax ERROR occurred ('$loss').\n$hline", $logp);
+			wlog (N, "QoS spec syntax ERROR occurred ('$loss').", $logp);
 			
 	    }
 	}
@@ -500,6 +501,13 @@ sub autoconfigure_debian_ubuntu {
     print INTERFACES "auto lo\n";
     print INTERFACES "iface lo inet loopback\n";
 
+	# Use of auto vs. allow-hotplug: 
+	#   - we use allow-hotplug in newer versions of Ubuntu to avoid long delays at startup
+	my $if_tag = 'auto';
+	if ($os_type =~ /^ubuntu-(\d+)/) {
+    	if ( $1 >= 16 ) { $if_tag = 'allow-hotplug'}
+	}
+
     # Network routes configuration: we read all <route> tags
     # and store the ip route configuration commands in @ip_routes
     my @ipv4_routes;       # Stores the IPv4 route configuration lines
@@ -552,9 +560,16 @@ sub autoconfigure_debian_ubuntu {
             $if_name = "eth" . $id;
         }
 
-        print RULES "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"" . $mac .  "\", ATTR{type}==\"1\", KERNEL==\"eth*\", NAME=\"" . $if_name . "\"\n\n";
-        #print RULES "KERNEL==\"eth*\", SYSFS{address}==\"" . $mac . "\", NAME=\"eth" . $id ."\"\n\n";
-        print INTERFACES "\nauto " . $if_name . "\n";
+		if ( ($os_type =~ /^ubuntu-(\d+)/) && ( $1 >= 19 ) ) { 
+        	print RULES "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"" . $mac .  "\", NAME=\"" . $if_name . "\"\n\n";
+	    } else {
+	        print RULES "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"" . $mac .  "\", ATTR{type}==\"1\", KERNEL==\"eth*\", NAME=\"" . $if_name . "\"\n\n";
+	        #print RULES "KERNEL==\"eth*\", SYSFS{address}==\"" . $mac . "\", NAME=\"eth" . $id ."\"\n\n";
+	    }
+
+
+
+        print INTERFACES "\n$if_tag $if_name\n";
 
         my @ipv4_tag_list = $if->getElementsByTagName("ipv4");
         my @ipv6_tag_list = $if->getElementsByTagName("ipv6");
@@ -661,17 +676,19 @@ sub autoconfigure_debian_ubuntu {
 	        if ($bw or $delay or $loss) {
 	        	# Apply interface specific values 
 	          	$qos = 'if';           	
-	        } else {
-	          	# Check if qos is specified in <net> tag
-	            my $net = $dh->get_net_byname($if->getAttribute("net"));
-		        $bw    = str($net->getAttribute("bw"));
-		        $delay = str($net->getAttribute("delay"));
-	    	    $loss  = str($net->getAttribute("loss"));
-	            if ($bw or $delay or $loss) {
-	            	# Apply interface specific values 
-	   	        	$qos = 'net';           	
-	            }
-	     	}
+	        } 
+	        # moved to vnx.pl
+	        # else {
+	        #  	# Check if qos is specified in <net> tag
+	        #    my $net = $dh->get_net_byname($if->getAttribute("net"));
+		    #    $bw    = str($net->getAttribute("bw"));
+		    #    $delay = str($net->getAttribute("delay"));
+	    	#    $loss  = str($net->getAttribute("loss"));
+	        #    if ($bw or $delay or $loss) {
+	        #    	# Apply interface specific values 
+	   	    #    	$qos = 'net';           	
+	        #    }
+	     	#}
 	        if ($qos) {
 	           	wlog (V, "QoS parameters specified in <$qos> tag for interface $id of vm $vm_name: bw='$bw', delay='$delay', loss='$loss'");
 	           	print INTERFACES "   # QoS parameters specified in <$qos> tag for interface $id: \n";


### PR DESCRIPTION
full XML (an access to $dh prevented it to work).
- vmAPI_lxc: created a link in /var/run/netns to make the containers
network namespaces visible to be used by "ip netns" command.
- vnx.pl and CheckSemantics: modified to allow use of relative paths in
ssh_key tags.